### PR TITLE
Fix: Address deno lint errors and warnings

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -43,7 +43,7 @@ function decodeCsvText(buffer: Uint8Array, isVerbose: boolean): string { // Add 
         );
         if (isVerbose) console.error("Successfully decoded as UTF-8 (no BOM)");
         return decoded;
-      } catch (utf8Error) {
+      } catch (_utf8Error) {
         // If UTF-8 fails, try Shift_JIS
         if (isVerbose) {
           console.error(
@@ -58,7 +58,7 @@ function decodeCsvText(buffer: Uint8Array, isVerbose: boolean): string { // Add 
           );
           if (isVerbose) console.error("Successfully decoded as Shift_JIS");
           return decoded;
-        } catch (shiftJisError) {
+        } catch (_shiftJisError) {
           console.error( // Always log the final failure
             "Failed to decode as both UTF-8 (no BOM) and Shift_JIS.",
             // shiftJisError // Optionally log the error details
@@ -91,7 +91,7 @@ function decodeCsvText(buffer: Uint8Array, isVerbose: boolean): string { // Add 
  */
 function processDataRows(
   originalDataRows: string[][],
-  originalHeader: string[], // Kept for context in warnings
+  _originalHeader: string[], // Kept for context in warnings
   startDateColIndex: number,
   endDateColIndex: number,
   maxDaysLimit: number,
@@ -162,7 +162,7 @@ function processDataRows(
       (1000 * 60 * 60 * 24);
     const totalDaysToExpand = dayDifference + 1;
 
-    let currentDate = new Date(startDate.getTime());
+    const currentDate = new Date(startDate.getTime());
     const finalEndDate = new Date(endDate.getTime());
     let expandedCount = 0;
     let loopCount = 0;

--- a/src/dateUtils.ts
+++ b/src/dateUtils.ts
@@ -69,7 +69,7 @@ export function parseDate(dateString: string | null | undefined): Date | null {
       }
       return utcDate;
     }
-  } catch (e) {
+  } catch (_e) {
     // Ignore errors from fallback constructor
   }
 

--- a/src/domHandler.ts
+++ b/src/domHandler.ts
@@ -88,7 +88,7 @@ export function populateColumnSelectors(columns: string[]): void {
   endDateColSelect.innerHTML = '<option value="">終了日の列を選択</option>';
 
   if (columns && columns.length > 0) {
-    columns.forEach((colName, index) => {
+    columns.forEach((colName, _index) => {
       // Use column name as value, or index if name is empty/duplicate?
       // For simplicity, let's use the column name as value for now.
       // Need to handle potential duplicate column names later if necessary.

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ async function updateSelectedFile(file: File | null): Promise<void> {
  * Reads and processes the given CSV file.
  * @param file The CSV file to process.
  */
-async function processFile(file: File): Promise<void> {
+function processFile(_file: File): void { // Removed async, added underscore to unused file
   // 1. Reset UI state (specific to processing start)
   clearError();
   clearStatus();
@@ -348,7 +348,7 @@ function decodeCsvText(arrayBuffer: ArrayBuffer): string {
  */
 function processDataRows(
   originalDataRows: string[][],
-  originalHeader: string[], // Added for context in warnings if needed later
+  _originalHeader: string[], // Added for context in warnings if needed later
   startDateColIndex: number,
   endDateColIndex: number,
   maxDaysLimit: number,
@@ -417,10 +417,10 @@ function processDataRows(
       (1000 * 60 * 60 * 24);
     const totalDaysToExpand = dayDifference + 1;
 
-    let currentDate = new Date(startDate.getTime());
+    const currentDate = new Date(startDate.getTime());
     const finalEndDate = new Date(endDate.getTime());
     let expandedCount = 0;
-    let truncated = false;
+    let _truncated = false; // Renamed unused variable
     let loopCount = 0;
     const maxLoops = Math.max(totalDaysToExpand + 10, maxDaysLimit + 10);
 
@@ -441,7 +441,7 @@ function processDataRows(
       currentDate.getTime() <= finalEndDate.getTime() &&
       loopCount < maxLoops
     ) {
-      truncated = true;
+      _truncated = true;
       truncationRowCount++;
       detailedWarnings.push({
         rowNumber: rowNumberForError,


### PR DESCRIPTION
This pull request fixes all errors and warnings reported by `deno lint`.

Changes include:
- Prefixing unused variables and arguments with underscores (`_`).
- Changing `let` to `const` for variables that are not reassigned.
- Removing the `async` keyword from functions that do not use `await`.

Commits were made per file for clarity:
- `fix(dateUtils): prefix unused catch variable with underscore`
- `fix(domHandler): prefix unused forEach index with underscore`
- `fix(cli): address lint errors (unused vars, prefer-const)`
- `fix(main): address lint errors (require-await, unused vars, prefer-const)`